### PR TITLE
Arc can't be open in any viewer

### DIFF
--- a/src/DXF/Arc.php
+++ b/src/DXF/Arc.php
@@ -37,7 +37,7 @@ class Arc extends Entity{
 	*/
 	function __toString(){
 		// TODO all are string values, maybee som should be decimal
-		return sprintf("0\nARC\n%s\n%s40\n%f\n50\n%f\n51\n%f",
+		return sprintf("0\nARC\n%s\n%s40\n%f\n50\n%f\n51\n%f\n",
 									$this->common(),
 									point($this->attributes['center']),
 									$this->attributes['radius'],


### PR DESCRIPTION
I don't know why, but Arc isn't visible on any of my DXF viewers unless I add "\n". I got the idea for adding it from Python library and seen it in Circle class of yours.
